### PR TITLE
Update JTS submodule name

### DIFF
--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>geogson-jts</artifactId>
     <packaging>jar</packaging>
 
-    <name>GeoGson Core</name>
+    <name>GeoGson JTS</name>
     <description>GeoJSON support for Google Gson - JTS</description>
 
     <dependencies>


### PR DESCRIPTION
Both maven submodules had the same name so I updated the JTS one to say 'GeoGson JTS' instead of  'GeoGson Core'
