### PR TITLE
JTS example in README.md results in StackOverflowError

### DIFF
--- a/core/src/main/java/com/github/filosganga/geogson/gson/GeometryAdapterFactory.java
+++ b/core/src/main/java/com/github/filosganga/geogson/gson/GeometryAdapterFactory.java
@@ -58,7 +58,7 @@ public class GeometryAdapterFactory implements TypeAdapterFactory {
         } else if (Positions.class.isAssignableFrom(type.getRawType())) {
             return (TypeAdapter<T>) new PositionsAdapter();
         } else {
-            return gson.getAdapter(type);
+            return null;
         }
     }
 


### PR DESCRIPTION
Ordering of TypeAdapterFactories seems to be wrong. Correct ordering might be:

```
Gson gson = new GsonBuilder()
  .registerTypeAdapterFactory(new GeometryAdapterFactory())
  .registerTypeAdapterFactory(new JtsAdapterFactory())
  .create();
```
