### PR TITLE
 handle JTS geometries that are null or empty correctly

### DIFF
--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsAdapterFactory.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsAdapterFactory.java
@@ -62,6 +62,9 @@ class JtsGeometryAdapter extends TypeAdapter<com.vividsolutions.jts.geom.Geometr
 
         Geometry<?> geometry = gson.getAdapter(new TypeToken<Geometry<?>>(){}).read(in);
 
+        if (geometry == null) {
+          return null;
+        }
         return codecRegistry.fromGeometry(geometry);
     }
 }

--- a/jts/src/test/java/com/github/filosganga/geogson/jts/JtsAdapterFactoryTest.java
+++ b/jts/src/test/java/com/github/filosganga/geogson/jts/JtsAdapterFactoryTest.java
@@ -1871,6 +1871,45 @@ public class JtsAdapterFactoryTest {
 
     }
 
+    @Test
+    public void shouldHandlePointEmpty() {
 
+        Point source = gf.createPoint((Coordinate) null);
 
+        Point parsed = toTest.fromJson(toTest.toJson(source), Point.class);
+
+        assertThat(true, is(source.isEmpty()));
+        assertThat(parsed, equalTo(null));
+    }
+
+    @Test
+    public void shouldHandleMultiPolgonEmpty() {
+
+        MultiPolygon source = gf.createMultiPolygon(null);
+
+        MultiPolygon parsed = toTest.fromJson(toTest.toJson(source), MultiPolygon.class);
+
+        assertThat(true, is(source.isEmpty()));
+        assertThat(parsed, equalTo(null));
+    }
+
+    @Test
+    public void shouldHandlePointNull() {
+
+        Point source = null;
+
+        Point parsed = toTest.fromJson(toTest.toJson(source), Point.class);
+
+        assertThat(parsed, equalTo(source));
+    }
+
+    @Test
+    public void shouldHandleMultiPolgonNull() {
+
+        MultiPolygon source = null;
+
+        MultiPolygon parsed = toTest.fromJson(toTest.toJson(source), MultiPolygon.class);
+
+        assertThat(parsed, equalTo(source));
+    }
 }


### PR DESCRIPTION
1) handle JTS geometries that are null or empty correctly (i.e contain no coordinates) correctly (same idea as in https://github.com/lurajon/geogson/commit/877b13c8f4d10b69cd1887e722076c94fea01999 )
2) added tests
