### PR TITLE
do not check lon and lat of Coordinates supporting also metric CRS

### DIFF
--- a/core/src/main/java/com/github/filosganga/geogson/model/Coordinates.java
+++ b/core/src/main/java/com/github/filosganga/geogson/model/Coordinates.java
@@ -16,9 +16,6 @@
 
 package com.github.filosganga.geogson.model;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Math.abs;
-
 import java.io.Serializable;
 
 import com.google.common.base.Objects;
@@ -28,13 +25,30 @@ import com.google.common.base.Objects;
  */
 public class Coordinates implements Serializable {
 
+    /**
+     * The x-axis coordinate in map units (degree, kilometer, meter, mile, foot
+     * and inch). If your map is in a geographic projection, this will be the
+     * Longitude. Otherwise, it will be the x coordinate of the map location in
+     * your map units.
+     */
     private final double lon;
+    /**
+     * The y-axis coordinate in map units (degree, kilometer, meter, mile, foot
+     * and inch). If your map is in a geographic projection, this will be the
+     * Latitude. Otherwise, it will be the y coordinate of the map location in
+     * your map units.
+     */
     private final double lat;
 
+    /**
+     * Create a new coordinate (a location on a map).
+     *
+     * @param lon
+     *          longitude, x-axis coordinate, see {@link Coordinates#lon lon}
+     * @param lat
+     *          latitude, y-axis coordinate, see {@link Coordinates#lat lat}
+     */
     private Coordinates(double lon, double lat) {
-
-        checkArgument(abs(lon) <= 180, "lon is out of range -180:180: " + lon);
-        checkArgument(abs(lat) <= 90, "lat is out of range -90:90: " + lat);
 
         this.lon = lon;
         this.lat = lat;

--- a/core/src/test/java/com/github/filosganga/geogson/model/CoordinatesTest.java
+++ b/core/src/test/java/com/github/filosganga/geogson/model/CoordinatesTest.java
@@ -20,37 +20,14 @@ import static com.github.filosganga.geogson.model.Matchers.positionWithLonLat;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
 
 /**
  * @author Filippo De Luca - me@filippodeluca.com
  */
 public class CoordinatesTest {
-
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorWithTooBigLonShouldRaiseException() {
-
-        Coordinates.of(181, 60);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorWithTooSmallLonShouldRaiseException() {
-
-        Coordinates.of(-181, 60);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorWithTooBigLatShouldRaiseException() {
-
-        Coordinates.of(0, 91);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorWithTooSmallLatShouldRaiseException() {
-
-        Coordinates.of(0, -91);
-    }
 
     @Test
     public void constructorWithBigLimitLonLatShouldReturnCoordinate() {


### PR DESCRIPTION
do not check lon and lat parameters in constructor of Coordinates supporting also metric CRS (Coordinate Reference Systems):

define lon and lat like in OpenLayers (see constructor http://dev.openlayers.org/releases/OpenLayers-2.13.1/doc/apidocs/files/OpenLayers/BaseTypes/LonLat-js.html )
allowing alternative map units (kilometer, meter, mile, foot and inch) additional to degree
(idea from http://dev.openlayers.org/releases/OpenLayers-2.13.1/doc/apidocs/files/OpenLayers/Map-js.html#OpenLayers.Map.units )
