### PR TITLE
#65: updated to latest JTS with package name change

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.github.filosganga</groupId>
         <artifactId>geogson</artifactId>
-        <version>2.0-SNAPHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geogson-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.github.filosganga</groupId>
         <artifactId>geogson</artifactId>
-        <version>1.4-SNAPHOT</version>
+        <version>2.0-SNAPHOT</version>
     </parent>
 
     <artifactId>geogson-core</artifactId>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.github.filosganga</groupId>
         <artifactId>geogson</artifactId>
-        <version>2.0-SNAPHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>geogson-jts</artifactId>

--- a/jts/pom.xml
+++ b/jts/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.github.filosganga</groupId>
         <artifactId>geogson</artifactId>
-        <version>1.4-SNAPHOT</version>
+        <version>2.0-SNAPHOT</version>
     </parent>
 
     <artifactId>geogson-jts</artifactId>
@@ -42,7 +42,7 @@
         </dependency>
 
         <dependency>
-            <groupId>com.vividsolutions</groupId>
+            <groupId>org.locationtech.jts</groupId>
             <artifactId>jts-core</artifactId>
         </dependency>
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/AbstractJtsCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/AbstractJtsCodec.java
@@ -2,8 +2,8 @@ package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.codec.Codec;
 import com.github.filosganga.geogson.model.*;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.ArrayList;
 import java.util.stream.StreamSupport;
@@ -43,9 +43,9 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
 
     // GeometryCollection ---
 
-    protected com.vividsolutions.jts.geom.Geometry toJtsGeometryCollection(Geometry<?> src) {
+    protected org.locationtech.jts.geom.Geometry toJtsGeometryCollection(Geometry<?> src) {
 
-        com.vividsolutions.jts.geom.Geometry returnGeometry;
+        org.locationtech.jts.geom.Geometry returnGeometry;
         if (src instanceof Point) {
             returnGeometry = toJtsPoint((Point) src);
         } else if (src instanceof LineString) {
@@ -53,51 +53,51 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
         } else if (src instanceof Polygon) {
             returnGeometry = toJtsPolygon((Polygon) src);
         } else if (src instanceof MultiPoint) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPoint, MultiPoint> codec = new MultiPointCodec(this.geometryFactory);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiPoint, MultiPoint> codec = new MultiPointCodec(this.geometryFactory);
             returnGeometry = codec.fromGeometry((MultiPoint) src);
         } else if (src instanceof MultiLineString) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiLineString, MultiLineString> codec = new MultiLineStringCodec(this.geometryFactory);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiLineString, MultiLineString> codec = new MultiLineStringCodec(this.geometryFactory);
             returnGeometry = codec.fromGeometry((MultiLineString) src);
         } else if (src instanceof MultiPolygon) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPolygon, MultiPolygon> codec = new MultiPolygonCodec(this.geometryFactory);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiPolygon, MultiPolygon> codec = new MultiPolygonCodec(this.geometryFactory);
             returnGeometry = codec.fromGeometry((MultiPolygon) src);
         } else if (src instanceof GeometryCollection) {
             GeometryCollection geometryCollection = (GeometryCollection) src;
             returnGeometry = this.geometryFactory.createGeometryCollection(StreamSupport.stream(geometryCollection.getGeometries().spliterator(), false)
                     .map(this::toJtsGeometryCollection)
-                    .toArray(com.vividsolutions.jts.geom.Geometry[]::new));
+                    .toArray(org.locationtech.jts.geom.Geometry[]::new));
         } else {
             throw new IllegalArgumentException("Unsupported geometry type: " + src.type());
         }
         return returnGeometry;
     }
 
-    protected Geometry<?> fromJtsGeometryCollection(com.vividsolutions.jts.geom.Geometry src) {
+    protected Geometry<?> fromJtsGeometryCollection(org.locationtech.jts.geom.Geometry src) {
         Geometry<?> returnGeometry;
         if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.GEOMETRY_COLLECTION.getValue())) {
             ArrayList<Geometry<?>> geometries = new ArrayList<Geometry<?>>();
             for (int i = 0; i < src.getNumGeometries(); i++) {
                 Geometry<?> geometry = null;
-                com.vividsolutions.jts.geom.Geometry jtsGeometry = src.getGeometryN(i);
+                org.locationtech.jts.geom.Geometry jtsGeometry = src.getGeometryN(i);
                 geometry = fromJtsGeometryCollection(jtsGeometry); // recursion!
                 geometries.add(geometry);
             }
             returnGeometry = GeometryCollection.of(geometries);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.POINT.getValue())) {
-            returnGeometry = fromJtsPoint((com.vividsolutions.jts.geom.Point) src);
+            returnGeometry = fromJtsPoint((org.locationtech.jts.geom.Point) src);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.LINE_STRING.getValue())) {
-            returnGeometry = fromJtsLineString((com.vividsolutions.jts.geom.LineString) src);
+            returnGeometry = fromJtsLineString((org.locationtech.jts.geom.LineString) src);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.POLYGON.getValue())) {
-            returnGeometry = fromJtsPolygon((com.vividsolutions.jts.geom.Polygon) src);
+            returnGeometry = fromJtsPolygon((org.locationtech.jts.geom.Polygon) src);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.MULTI_POINT.getValue())) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPoint, MultiPoint> codec = new MultiPointCodec(this.geometryFactory);
-            returnGeometry = codec.toGeometry((com.vividsolutions.jts.geom.MultiPoint) src);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiPoint, MultiPoint> codec = new MultiPointCodec(this.geometryFactory);
+            returnGeometry = codec.toGeometry((org.locationtech.jts.geom.MultiPoint) src);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.MULTI_LINE_STRING.getValue())) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiLineString, MultiLineString> codec = new MultiLineStringCodec(this.geometryFactory);
-            returnGeometry = codec.toGeometry((com.vividsolutions.jts.geom.MultiLineString) src);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiLineString, MultiLineString> codec = new MultiLineStringCodec(this.geometryFactory);
+            returnGeometry = codec.toGeometry((org.locationtech.jts.geom.MultiLineString) src);
         } else if (src.getGeometryType().equalsIgnoreCase(Geometry.Type.MULTI_POLYGON.getValue())) {
-            AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPolygon, MultiPolygon> codec = new MultiPolygonCodec(this.geometryFactory);
-            returnGeometry = codec.toGeometry((com.vividsolutions.jts.geom.MultiPolygon) src);
+            AbstractJtsCodec<org.locationtech.jts.geom.MultiPolygon, MultiPolygon> codec = new MultiPolygonCodec(this.geometryFactory);
+            returnGeometry = codec.toGeometry((org.locationtech.jts.geom.MultiPolygon) src);
         } else {
             throw new IllegalArgumentException("Unsupported geometry type: " + src.getGeometryType());
         }
@@ -108,19 +108,19 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
     // Polygon ---
 
 
-    protected com.vividsolutions.jts.geom.Polygon toJtsPolygon(Polygon src) {
+    protected org.locationtech.jts.geom.Polygon toJtsPolygon(Polygon src) {
 
         return this.geometryFactory.createPolygon(
                 toJtsLinearRing(src.perimeter()),
                 StreamSupport
                         .stream(src.holes().spliterator(), false)
                         .map(this::toJtsLinearRing)
-                        .toArray(com.vividsolutions.jts.geom.LinearRing[]::new)
+                        .toArray(org.locationtech.jts.geom.LinearRing[]::new)
         );
     }
 
 
-    protected static Polygon fromJtsPolygon(com.vividsolutions.jts.geom.Polygon src) {
+    protected static Polygon fromJtsPolygon(org.locationtech.jts.geom.Polygon src) {
 
         return Polygon.of(
                 fromJtsLineString(src.getExteriorRing()).toLinearRing(),
@@ -133,7 +133,7 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
 
     // LinearRing ---
 
-    protected com.vividsolutions.jts.geom.LinearRing toJtsLinearRing(LinearRing src) {
+    protected org.locationtech.jts.geom.LinearRing toJtsLinearRing(LinearRing src) {
 
         return this.geometryFactory.createLinearRing(
                 StreamSupport.stream(src.positions().children().spliterator(), false)
@@ -144,7 +144,7 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
     }
 
 
-    protected static LinearRing fromJtsLinearRing(com.vividsolutions.jts.geom.LinearRing src) {
+    protected static LinearRing fromJtsLinearRing(org.locationtech.jts.geom.LinearRing src) {
         return LinearRing.of(StreamSupport
                 .stream(JtsPointIterable.of(src).spliterator(), false)
                 .map(AbstractJtsCodec::fromJtsPoint)::iterator
@@ -154,7 +154,7 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
     // LineString ---
 
 
-    protected com.vividsolutions.jts.geom.LineString toJtsLineString(LineString src) {
+    protected org.locationtech.jts.geom.LineString toJtsLineString(LineString src) {
 
         return this.geometryFactory.createLineString(
                 StreamSupport.stream(src.positions().children().spliterator(), false)
@@ -164,7 +164,7 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
         );
     }
 
-    protected static LineString fromJtsLineString(com.vividsolutions.jts.geom.LineString src) {
+    protected static LineString fromJtsLineString(org.locationtech.jts.geom.LineString src) {
         return LineString.of(StreamSupport.stream(JtsPointIterable.of(src).spliterator(), false)
                 .map(AbstractJtsCodec::fromJtsPoint)
         );
@@ -172,12 +172,12 @@ public abstract class AbstractJtsCodec<S, T extends Geometry<?>> implements Code
 
     // Point
 
-    protected static com.vividsolutions.jts.geom.Point toJtsPoint(Point src) {
+    protected static org.locationtech.jts.geom.Point toJtsPoint(Point src) {
         return new GeometryFactory().createPoint(new Coordinate(src.lon(), src.lat()));
     }
 
 
-    protected static Point fromJtsPoint(com.vividsolutions.jts.geom.Point src) {
+    protected static Point fromJtsPoint(org.locationtech.jts.geom.Point src) {
         Coordinate coordinate = src.getCoordinate();
         return Point.from(coordinate.x, coordinate.y, coordinate.z);
     }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/GeometryCollectionCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/GeometryCollectionCodec.java
@@ -2,18 +2,18 @@ package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.Geometry;
 import com.github.filosganga.geogson.model.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.stream.StreamSupport;
 
 /**
- * Codec for a {@link com.vividsolutions.jts.geom.GeometryCollection JTS
+ * Codec for a {@link org.locationtech.jts.geom.GeometryCollection JTS
  * GeometryCollection}
  */
-public class GeometryCollectionCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.GeometryCollection, GeometryCollection> {
+public class GeometryCollectionCodec extends AbstractJtsCodec<org.locationtech.jts.geom.GeometryCollection, GeometryCollection> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.GeometryCollection JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.GeometryCollection JTS
      * GeometryCollection} with a given {@link GeometryFactory}
      *
      * @param geometryFactory a {@link GeometryFactory} defining a PrecisionModel and a SRID
@@ -23,7 +23,7 @@ public class GeometryCollectionCodec extends AbstractJtsCodec<com.vividsolutions
     }
 
     @Override
-    public GeometryCollection toGeometry(com.vividsolutions.jts.geom.GeometryCollection src) {
+    public GeometryCollection toGeometry(org.locationtech.jts.geom.GeometryCollection src) {
         return GeometryCollection.of(StreamSupport.stream(JtsGeometryCollectionIterable.of(src).spliterator(), false)
                 .map(this::fromJtsGeometryCollection)
                 .toArray(Geometry<?>[]::new)
@@ -31,11 +31,11 @@ public class GeometryCollectionCodec extends AbstractJtsCodec<com.vividsolutions
     }
 
     @Override
-    public com.vividsolutions.jts.geom.GeometryCollection fromGeometry(GeometryCollection src) {
+    public org.locationtech.jts.geom.GeometryCollection fromGeometry(GeometryCollection src) {
         return this.geometryFactory.createGeometryCollection(
                 StreamSupport.stream(src.getGeometries().spliterator(), false)
                         .map(this::toJtsGeometryCollection)
-                        .toArray(com.vividsolutions.jts.geom.Geometry[]::new)
+                        .toArray(org.locationtech.jts.geom.Geometry[]::new)
         );
     }
 }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsAdapterFactory.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsAdapterFactory.java
@@ -8,7 +8,7 @@ import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.io.IOException;
 
@@ -34,7 +34,7 @@ public class JtsAdapterFactory implements TypeAdapterFactory {
     private final GeometryFactory geometryFactory;
 
     /**
-     * Create an adapter for {@link com.vividsolutions.jts.geom.Geometry JTS
+     * Create an adapter for {@link org.locationtech.jts.geom.Geometry JTS
      * Geometry} with a default {@link GeometryFactory} (i.e. using the
      * {@link GeometryFactory#GeometryFactory() empty constructor})
      *
@@ -44,7 +44,7 @@ public class JtsAdapterFactory implements TypeAdapterFactory {
     }
 
     /**
-     * Create an adapter for {@link com.vividsolutions.jts.geom.Geometry JTS
+     * Create an adapter for {@link org.locationtech.jts.geom.Geometry JTS
      * Geometry} with an optional {@link GeometryFactory}
      *
      * @param geometryFactory
@@ -62,7 +62,7 @@ public class JtsAdapterFactory implements TypeAdapterFactory {
     @Override
     public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
 
-        if(com.vividsolutions.jts.geom.Geometry.class.isAssignableFrom(type.getRawType())) {
+        if(org.locationtech.jts.geom.Geometry.class.isAssignableFrom(type.getRawType())) {
             return (TypeAdapter<T>) new JtsGeometryAdapter(gson, getGeometryFactory());
         } else {
             return null;
@@ -80,11 +80,11 @@ public class JtsAdapterFactory implements TypeAdapterFactory {
 
 }
 
-class JtsGeometryAdapter extends TypeAdapter<com.vividsolutions.jts.geom.Geometry> {
+class JtsGeometryAdapter extends TypeAdapter<org.locationtech.jts.geom.Geometry> {
 
     private final Gson gson;
 
-    private final CodecRegistry<com.vividsolutions.jts.geom.Geometry, Geometry<?>> codecRegistry;
+    private final CodecRegistry<org.locationtech.jts.geom.Geometry, Geometry<?>> codecRegistry;
 
     public JtsGeometryAdapter(Gson gson, GeometryFactory geometryFactory) {
         this.gson = gson;
@@ -100,7 +100,7 @@ class JtsGeometryAdapter extends TypeAdapter<com.vividsolutions.jts.geom.Geometr
     }
 
     @Override
-    public void write(JsonWriter out, com.vividsolutions.jts.geom.Geometry value) throws IOException {
+    public void write(JsonWriter out, org.locationtech.jts.geom.Geometry value) throws IOException {
         if (value == null || value.getCoordinates().length == 0) {
             out.nullValue();
             return;
@@ -111,7 +111,7 @@ class JtsGeometryAdapter extends TypeAdapter<com.vividsolutions.jts.geom.Geometr
     }
 
     @Override
-    public com.vividsolutions.jts.geom.Geometry read(JsonReader in) throws IOException {
+    public org.locationtech.jts.geom.Geometry read(JsonReader in) throws IOException {
 
         Geometry<?> geometry = gson.getAdapter(new TypeToken<Geometry<?>>(){}).read(in);
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsGeometryCollectionIterable.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsGeometryCollectionIterable.java
@@ -1,7 +1,7 @@
 package com.github.filosganga.geogson.jts;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
 
 import java.util.Iterator;
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsLineStringIterable.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsLineStringIterable.java
@@ -1,8 +1,8 @@
 package com.github.filosganga.geogson.jts;
 
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.Polygon;
 
 import java.util.Iterator;
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsPointIterable.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsPointIterable.java
@@ -1,8 +1,8 @@
 package com.github.filosganga.geogson.jts;
 
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.Point;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.Point;
 
 import java.util.Iterator;
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/JtsPolygonIterable.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/JtsPolygonIterable.java
@@ -1,7 +1,7 @@
 package com.github.filosganga.geogson.jts;
 
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
 
 import java.util.Iterator;
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/LineStringCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/LineStringCodec.java
@@ -1,16 +1,16 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.LineString;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.LineString} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.LineString} and
  * {@link LineString}.
  */
-public class LineStringCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.LineString, LineString> {
+public class LineStringCodec extends AbstractJtsCodec<org.locationtech.jts.geom.LineString, LineString> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.LineString JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.LineString JTS
      * LineString} with a given {@link GeometryFactory}
      *
      * @param geometryFactory
@@ -21,12 +21,12 @@ public class LineStringCodec extends AbstractJtsCodec<com.vividsolutions.jts.geo
     }
 
     @Override
-    public LineString toGeometry(com.vividsolutions.jts.geom.LineString src) {
+    public LineString toGeometry(org.locationtech.jts.geom.LineString src) {
         return fromJtsLineString(src);
     }
 
     @Override
-    public com.vividsolutions.jts.geom.LineString fromGeometry(LineString src) {
+    public org.locationtech.jts.geom.LineString fromGeometry(LineString src) {
         return toJtsLineString(src);
     }
 }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/LinearRingCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/LinearRingCodec.java
@@ -1,16 +1,16 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.LinearRing;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.LinearRing} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.LinearRing} and
  * {@link LinearRing}.
  */
-public class LinearRingCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.LinearRing, LinearRing> {
+public class LinearRingCodec extends AbstractJtsCodec<org.locationtech.jts.geom.LinearRing, LinearRing> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.LinearRing JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.LinearRing JTS
      * LinearRing} with a given {@link GeometryFactory}
      *
      * @param geometryFactory
@@ -21,12 +21,12 @@ public class LinearRingCodec extends AbstractJtsCodec<com.vividsolutions.jts.geo
     }
 
     @Override
-    public LinearRing toGeometry(com.vividsolutions.jts.geom.LinearRing src) {
+    public LinearRing toGeometry(org.locationtech.jts.geom.LinearRing src) {
         return fromJtsLinearRing(src);
     }
 
     @Override
-    public com.vividsolutions.jts.geom.LinearRing fromGeometry(LinearRing src) {
+    public org.locationtech.jts.geom.LinearRing fromGeometry(LinearRing src) {
         return toJtsLinearRing(src);
     }
 }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/MultiLineStringCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/MultiLineStringCodec.java
@@ -1,18 +1,18 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.MultiLineString;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.stream.StreamSupport;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.MultiLineString} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.MultiLineString} and
  * {@link MultiLineString}.
  */
-public class MultiLineStringCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.MultiLineString, MultiLineString> {
+public class MultiLineStringCodec extends AbstractJtsCodec<org.locationtech.jts.geom.MultiLineString, MultiLineString> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.MultiLineString JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.MultiLineString JTS
      * MultiLineString} with a given {@link GeometryFactory}
      *
      * @param geometryFactory a {@link GeometryFactory} defining a PrecisionModel and a SRID
@@ -22,17 +22,17 @@ public class MultiLineStringCodec extends AbstractJtsCodec<com.vividsolutions.jt
     }
 
     @Override
-    public MultiLineString toGeometry(com.vividsolutions.jts.geom.MultiLineString src) {
+    public MultiLineString toGeometry(org.locationtech.jts.geom.MultiLineString src) {
         return MultiLineString.of(StreamSupport.stream(JtsLineStringIterable.of(src).spliterator(), false)
                 .map(AbstractJtsCodec::fromJtsLineString));
     }
 
     @Override
-    public com.vividsolutions.jts.geom.MultiLineString fromGeometry(MultiLineString src) {
+    public org.locationtech.jts.geom.MultiLineString fromGeometry(MultiLineString src) {
         return this.geometryFactory.createMultiLineString(
                 StreamSupport.stream(src.lineStrings().spliterator(), false)
                         .map(this::toJtsLineString)
-                        .toArray(com.vividsolutions.jts.geom.LineString[]::new)
+                        .toArray(org.locationtech.jts.geom.LineString[]::new)
         );
     }
 }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/MultiPointCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/MultiPointCodec.java
@@ -1,19 +1,19 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.MultiPoint;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.stream.StreamSupport;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.MultiPoint} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.MultiPoint} and
  * {@link MultiPoint}.
  */
-public class MultiPointCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPoint, MultiPoint> {
+public class MultiPointCodec extends AbstractJtsCodec<org.locationtech.jts.geom.MultiPoint, MultiPoint> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.MultiPoint JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.MultiPoint JTS
      * MultiPoint} with a given {@link GeometryFactory}
      *
      * @param geometryFactory a {@link GeometryFactory} defining a PrecisionModel and a SRID
@@ -23,13 +23,13 @@ public class MultiPointCodec extends AbstractJtsCodec<com.vividsolutions.jts.geo
     }
 
     @Override
-    public MultiPoint toGeometry(com.vividsolutions.jts.geom.MultiPoint src) {
+    public MultiPoint toGeometry(org.locationtech.jts.geom.MultiPoint src) {
         return MultiPoint.of(StreamSupport.stream(JtsPointIterable.of(src).spliterator(), false)
                 .map(AbstractJtsCodec::fromJtsPoint));
     }
 
     @Override
-    public com.vividsolutions.jts.geom.MultiPoint fromGeometry(MultiPoint src) {
+    public org.locationtech.jts.geom.MultiPoint fromGeometry(MultiPoint src) {
         return this.geometryFactory.createMultiPoint(
                 src.points().stream()
                         .map(p -> new Coordinate(p.lon(), p.lat(), p.alt()))

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/MultiPolygonCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/MultiPolygonCodec.java
@@ -1,18 +1,18 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.MultiPolygon;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 import java.util.stream.StreamSupport;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.MultiPolygon} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.MultiPolygon} and
  * {@link MultiPolygon}.
  */
-public class MultiPolygonCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.MultiPolygon, MultiPolygon> {
+public class MultiPolygonCodec extends AbstractJtsCodec<org.locationtech.jts.geom.MultiPolygon, MultiPolygon> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.MultiPolygon JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.MultiPolygon JTS
      * MultiPolygon} with a given {@link GeometryFactory}
      *
      * @param geometryFactory a {@link GeometryFactory} defining a PrecisionModel and a SRID
@@ -22,16 +22,16 @@ public class MultiPolygonCodec extends AbstractJtsCodec<com.vividsolutions.jts.g
     }
 
     @Override
-    public MultiPolygon toGeometry(com.vividsolutions.jts.geom.MultiPolygon src) {
+    public MultiPolygon toGeometry(org.locationtech.jts.geom.MultiPolygon src) {
         return MultiPolygon.of(StreamSupport.stream(JtsPolygonIterable.of(src).spliterator(), false)
                 .map(AbstractJtsCodec::fromJtsPolygon));
     }
 
     @Override
-    public com.vividsolutions.jts.geom.MultiPolygon fromGeometry(MultiPolygon src) {
+    public org.locationtech.jts.geom.MultiPolygon fromGeometry(MultiPolygon src) {
         return this.geometryFactory.createMultiPolygon(
                 StreamSupport.stream(src.polygons().spliterator(), false)
                         .map(this::toJtsPolygon)
-                        .toArray(com.vividsolutions.jts.geom.Polygon[]::new));
+                        .toArray(org.locationtech.jts.geom.Polygon[]::new));
     }
 }

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/PointCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/PointCodec.java
@@ -1,17 +1,17 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.Point;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.Point} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.Point} and
  * {@link Point}.
  */
-public class PointCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.Point, Point> {
+public class PointCodec extends AbstractJtsCodec<org.locationtech.jts.geom.Point, Point> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.Point JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.Point JTS
      * Point} with a given {@link GeometryFactory}
      *
      * @param geometryFactory
@@ -22,12 +22,12 @@ public class PointCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.Poi
     }
 
     @Override
-    public Point toGeometry(com.vividsolutions.jts.geom.Point src) {
+    public Point toGeometry(org.locationtech.jts.geom.Point src) {
         return fromJtsPoint(src);
     }
 
     @Override
-    public com.vividsolutions.jts.geom.Point fromGeometry(Point src) {
+    public org.locationtech.jts.geom.Point fromGeometry(Point src) {
         return this.geometryFactory.createPoint(new Coordinate(src.lon(), src.lat()));
     }
 

--- a/jts/src/main/java/com/github/filosganga/geogson/jts/PolygonCodec.java
+++ b/jts/src/main/java/com/github/filosganga/geogson/jts/PolygonCodec.java
@@ -1,16 +1,16 @@
 package com.github.filosganga.geogson.jts;
 
 import com.github.filosganga.geogson.model.Polygon;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
- * A {@link com.github.filosganga.geogson.codec.Codec} for {@link com.vividsolutions.jts.geom.Polygon} and
+ * A {@link com.github.filosganga.geogson.codec.Codec} for {@link org.locationtech.jts.geom.Polygon} and
  * {@link Polygon}.
  */
-public class PolygonCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.Polygon, Polygon> {
+public class PolygonCodec extends AbstractJtsCodec<org.locationtech.jts.geom.Polygon, Polygon> {
 
     /**
-     * Create a codec for a {@link com.vividsolutions.jts.geom.Polygon JTS
+     * Create a codec for a {@link org.locationtech.jts.geom.Polygon JTS
      * Polygon} with a given {@link GeometryFactory}
      *
      * @param geometryFactory
@@ -21,12 +21,12 @@ public class PolygonCodec extends AbstractJtsCodec<com.vividsolutions.jts.geom.P
     }
 
     @Override
-    public Polygon toGeometry(com.vividsolutions.jts.geom.Polygon src) {
+    public Polygon toGeometry(org.locationtech.jts.geom.Polygon src) {
         return fromJtsPolygon(src);
     }
 
     @Override
-    public com.vividsolutions.jts.geom.Polygon fromGeometry(Polygon src) {
+    public org.locationtech.jts.geom.Polygon fromGeometry(Polygon src) {
         return toJtsPolygon(src);
     }
 }

--- a/jts/src/test/java/com/github/filosganga/geogson/jts/CodecRegistryTest.java
+++ b/jts/src/test/java/com/github/filosganga/geogson/jts/CodecRegistryTest.java
@@ -3,7 +3,7 @@ package com.github.filosganga.geogson.jts;
 import com.github.filosganga.geogson.codec.CodecRegistry;
 import com.github.filosganga.geogson.model.Geometry;
 import com.github.filosganga.geogson.model.Point;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,11 +13,11 @@ public class CodecRegistryTest {
 
     @Test
     public void testAddCodec() throws Exception {
-        CodecRegistry<com.vividsolutions.jts.geom.Geometry, Geometry<?>> codecs = new CodecRegistry<com.vividsolutions.jts.geom.Geometry, Geometry<?>>();
+        CodecRegistry<org.locationtech.jts.geom.Geometry, Geometry<?>> codecs = new CodecRegistry<org.locationtech.jts.geom.Geometry, Geometry<?>>();
         codecs.addCodec(new PointCodec(new GeometryFactory()));
 
-        com.vividsolutions.jts.geom.Geometry value = codecs.fromGeometry(Point.from(12.6, 43.6));
+        org.locationtech.jts.geom.Geometry value = codecs.fromGeometry(Point.from(12.6, 43.6));
 
-        assertThat(value, instanceOf(com.vividsolutions.jts.geom.Point.class));
+        assertThat(value, instanceOf(org.locationtech.jts.geom.Point.class));
     }
 }

--- a/jts/src/test/java/com/github/filosganga/geogson/jts/JtsAdapterFactoryTest.java
+++ b/jts/src/test/java/com/github/filosganga/geogson/jts/JtsAdapterFactoryTest.java
@@ -19,8 +19,8 @@ package com.github.filosganga.geogson.jts;
 import com.github.filosganga.geogson.gson.GeometryAdapterFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.vividsolutions.jts.geom.*;
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.github.filosganga</groupId>
     <artifactId>geogson</artifactId>
-    <version>2.0-SNAPHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>com.github.filosganga</groupId>
     <artifactId>geogson</artifactId>
-    <version>1.4-SNAPHOT</version>
+    <version>2.0-SNAPHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -116,9 +116,9 @@
             </dependency>
 
             <dependency>
-                <groupId>com.vividsolutions</groupId>
+                <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
-                <version>1.14.0</version>
+                <version>1.16.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Updated JTS to latest 1.16.0 version with dependency name change (was com.vividsolutions.jts but from 1.15.0 it is org.locationtech.jts).

Updated version to 2.0 since this is a breaking change.

See https://github.com/locationtech/jts/blob/master/MIGRATION.md